### PR TITLE
Splunkhec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [#3551](https://github.com/influxdata/telegraf/pull/3551): Add health status mapping from string to int in elasticsearch input.
 - [#3580](https://github.com/influxdata/telegraf/pull/3580): Add control over which stats to gather in basicstats aggregator.
+- [#3596](https://github.com/influxdata/telegraf/pull/3596): Add messages_delivered_get to rabbitmq input.
 
 ### Bugfixes
 

--- a/plugins/inputs/dcos/README.md
+++ b/plugins/inputs/dcos/README.md
@@ -106,7 +106,7 @@ the cluster.  For more information on this technique reference
 ### Metrics:
 
 Please consult the [Metrics Reference](https://docs.mesosphere.com/1.10/metrics/reference/)
-for details on interprete field interpretation.
+for details about field interpretation.
 
 - dcos_node
   - tags:

--- a/plugins/inputs/haproxy/README.md
+++ b/plugins/inputs/haproxy/README.md
@@ -58,8 +58,8 @@ When using socket names, wildcard expansion is supported so plugin can gather
 stats from multiple sockets at once.
 
 To use HTTP Basic Auth add the username and password in the userinfo section
-of the URL: `http://user:password@1.2.3.4/haproxy?stats`.  The credentials sent via the
-`Authorization` header and not using the request URL.
+of the URL: `http://user:password@1.2.3.4/haproxy?stats`.  The credentials are
+sent via the `Authorization` header and not using the request URL.
 
 
 #### keep_field_names

--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -52,6 +52,7 @@ For additional details reference the [RabbitMQ Management HTTP Stats](https://cd
   - messages (int, messages)
   - messages_acked (int, messages)
   - messages_delivered (int, messages)
+  - messages_delivered_get (int, messages)
   - messages_published (int, messages)
   - messages_ready (int, messages)
   - messages_unacked (int, messages)
@@ -115,6 +116,12 @@ For additional details reference the [RabbitMQ Management HTTP Stats](https://cd
 
 ### Sample Queries:
 
+Message rates for the entire node can be calculated from total message counts. For instance, to get the rate of messages published per minute, use this query:
+
+```
+SELECT NON_NEGATIVE_DERIVATIVE(LAST("messages_published"), 1m) AS messages_published_rate
+FROM rabbitmq_overview WHERE time > now() - 10m GROUP BY time(1m)
+```
 
 ### Example Output:
 

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -268,17 +268,18 @@ func gatherOverview(r *RabbitMQ, acc telegraf.Accumulator) {
 		tags["name"] = r.Name
 	}
 	fields := map[string]interface{}{
-		"messages":           overview.QueueTotals.Messages,
-		"messages_ready":     overview.QueueTotals.MessagesReady,
-		"messages_unacked":   overview.QueueTotals.MessagesUnacknowledged,
-		"channels":           overview.ObjectTotals.Channels,
-		"connections":        overview.ObjectTotals.Connections,
-		"consumers":          overview.ObjectTotals.Consumers,
-		"exchanges":          overview.ObjectTotals.Exchanges,
-		"queues":             overview.ObjectTotals.Queues,
-		"messages_acked":     overview.MessageStats.Ack,
-		"messages_delivered": overview.MessageStats.Deliver,
-		"messages_published": overview.MessageStats.Publish,
+		"messages":               overview.QueueTotals.Messages,
+		"messages_ready":         overview.QueueTotals.MessagesReady,
+		"messages_unacked":       overview.QueueTotals.MessagesUnacknowledged,
+		"channels":               overview.ObjectTotals.Channels,
+		"connections":            overview.ObjectTotals.Connections,
+		"consumers":              overview.ObjectTotals.Consumers,
+		"exchanges":              overview.ObjectTotals.Exchanges,
+		"queues":                 overview.ObjectTotals.Queues,
+		"messages_acked":         overview.MessageStats.Ack,
+		"messages_delivered":     overview.MessageStats.Deliver,
+		"messages_delivered_get": overview.MessageStats.DeliverGet,
+		"messages_published":     overview.MessageStats.Publish,
 	}
 	acc.AddFields("rabbitmq_overview", fields, tags)
 }

--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/prometheus_client"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann_legacy"
+	_ "github.com/influxdata/telegraf/plugins/outputs/splunkhec"
 	_ "github.com/influxdata/telegraf/plugins/outputs/socket_writer"
 	_ "github.com/influxdata/telegraf/plugins/outputs/wavefront"
 )

--- a/plugins/outputs/splunkhec/README.md
+++ b/plugins/outputs/splunkhec/README.md
@@ -1,0 +1,9 @@
+# Datadog Output Plugin
+
+This plugin writes to the [Datadog Metrics API](http://docs.datadoghq.com/api/#metrics)
+and requires an `apikey` which can be obtained [here](https://app.datadoghq.com/account/settings#api)
+for the account.
+
+If the point value being sent cannot be converted to a float64, the metric is skipped.
+
+Metrics are grouped by converting any `_` characters to `.` in the Point Name.

--- a/plugins/outputs/splunkhec/README.md
+++ b/plugins/outputs/splunkhec/README.md
@@ -1,9 +1,7 @@
-# Datadog Output Plugin
+# Splunk HEC Output Plugin
 
-This plugin writes to the [Datadog Metrics API](http://docs.datadoghq.com/api/#metrics)
-and requires an `apikey` which can be obtained [here](https://app.datadoghq.com/account/settings#api)
-for the account.
+This plugin writes to the [Splunk HEC API](http://dev.splunk.com/view/event-collector/SP-CAAAFDN)
+and requires an `token` which can be obtained by following instructions [here](https://docs.splunk.com/Documentation/Splunk/7.0.1/Metrics/GetMetricsInOther#Get_metrics_in_from_clients_over_HTTP_or_HTTPS)
+for your Splunk Enterprise installation.
 
-If the point value being sent cannot be converted to a float64, the metric is skipped.
-
-Metrics are grouped by converting any `_` characters to `.` in the Point Name.
+If the value being sent cannot be converted to a float64, the metric is skipped.

--- a/plugins/outputs/splunkhec/splunkhec.go
+++ b/plugins/outputs/splunkhec/splunkhec.go
@@ -3,6 +3,7 @@ package splunkhec
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -14,12 +15,12 @@ import (
 
 type SplunkHEC struct {
 	Token  string
-	Url string
-    Index string
-    Source string
+	Url    string
+	Index  string
+	Source string
 
 	Timeout internal.Duration
-	client *http.Client
+	client  *http.Client
 }
 
 var sampleConfig = `
@@ -39,22 +40,18 @@ var sampleConfig = `
   # timeout = "5s"
 `
 
-
 /* Splunk HEC Structs */
 type HECTimeSeries struct {
-    Time    float64     `json:"time"`
-    Event   string      `json:"event"`
-    Index   string      `json:"index,omitempty"`
-    Source  string      `json:"source,omitempty"`
-    Host    string      `json:"host"`
-    Fields  interface{} `json:"fields"`
-
+	Time   float64     `json:"time"`
+	Event  string      `json:"event"`
+	Index  string      `json:"index,omitempty"`
+	Source string      `json:"source,omitempty"`
+	Host   string      `json:"host"`
+	Fields interface{} `json:"fields"`
 }
 
-
 func NewSplunkHEC() *SplunkHEC {
-	return &SplunkHEC{
-	}
+	return &SplunkHEC{}
 }
 
 func (d *SplunkHEC) Connect() error {
@@ -75,20 +72,21 @@ func (d *SplunkHEC) Connect() error {
 }
 
 func (d *SplunkHEC) Write(metrics []telegraf.Metric) error {
+
+	const redactedApiKey = "****************"
+
 	if len(metrics) == 0 {
 		return nil
 	}
-    var hecPostData string
+	var hecPostData string
 
 	for _, m := range metrics {
-		if hecMs, err := buildMetrics(m,d); err == nil {
-            hecPostData = hecPostData+string(hecMs)
-        } else {
+		if hecMs, err := buildMetrics(m, d); err == nil {
+			hecPostData = hecPostData + string(hecMs)
+		} else {
 			log.Printf("I! unable to build Metric for %s, skipping\n", m.Name())
 		}
 	}
-
-	redactedApiKey := "****************"
 
 	req, err := http.NewRequest("POST", d.Url, strings.NewReader(hecPostData))
 	if err != nil {
@@ -97,7 +95,7 @@ func (d *SplunkHEC) Write(metrics []telegraf.Metric) error {
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Splunk "+d.Token)
-    // Add the Request-Channel header incase Indexer Acknowledgment is enabled.
+	// Add the Request-Channel header incase Indexer Acknowledgment is enabled.
 	req.Header.Add("X-Splunk-Request-Channel", d.Token)
 
 	resp, err := d.client.Do(req)
@@ -107,7 +105,8 @@ func (d *SplunkHEC) Write(metrics []telegraf.Metric) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 209 {
-		return fmt.Errorf("received bad status code, %d\n", resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("received bad status code, %d [%s]\n", resp.StatusCode, body)
 	}
 
 	return nil
@@ -121,76 +120,75 @@ func (d *SplunkHEC) Description() string {
 	return "Configuration for Splunk HEC to send metrics to.\nDoes not make use of Indexer Acknowledgement"
 }
 
-func buildMetrics(m telegraf.Metric,d *SplunkHEC) (string, error) {
+func buildMetrics(m telegraf.Metric, d *SplunkHEC) (string, error) {
 
-    var metricGroup string
-    dataGroup := HECTimeSeries{}
-    obj := map[string]interface{}{}
+	var metricGroup string
+	dataGroup := HECTimeSeries{}
+	obj := map[string]interface{}{}
 
 	for k, v := range m.Fields() {
-        // Empty out anything in obj since I don't know how golang scoping works...
-        for k,_ := range obj {
-	        delete(obj,k)
-	    }
-        dataGroup = HECTimeSeries{}
-        obj["metric_name"] = m.Name()+"."+k
-        obj["_value"] = v
+		// Empty out anything in obj since I don't know how golang scoping works...
+		for k, _ := range obj {
+			delete(obj, k)
+		}
+		dataGroup = HECTimeSeries{}
+		obj["metric_name"] = m.Name() + "." + k
+		obj["_value"] = v
 
-        dataGroup = HECTimeSeries {
-            Time:   float64(m.Time().UnixNano()/1000000000),
-            Event:  "metric",
-            Fields: obj,
-        }
+		dataGroup = HECTimeSeries{
+			Time:   float64(m.Time().UnixNano() / 1000000000),
+			Event:  "metric",
+			Fields: obj,
+		}
 
-	    if d.Source != "" {
-            dataGroup.Source = d.Source
-        } else {
-            dataGroup.Source = "telegraf"
-        }
-	    if d.Index != "" {
-            dataGroup.Index = d.Index
-        }
+		if d.Source != "" {
+			dataGroup.Source = d.Source
+		} else {
+			dataGroup.Source = "telegraf"
+		}
+		if d.Index != "" {
+			dataGroup.Index = d.Index
+		}
 
 		if !verifyValue(v) {
-            // Reset the dataGroup
-            dataGroup = HECTimeSeries{}
+			// Reset the dataGroup
+			dataGroup = HECTimeSeries{}
 			continue
 		}
 
-        // Need to get Host from m.Tags()
-        buildHecTags(m, &dataGroup)
-        b, err := json.Marshal(dataGroup)
-        if err != nil {
-            fmt.Println("error:", err)
-        }
-        metricGroup = metricGroup+string(b)
+		// Need to get Host from m.Tags()
+		buildHecTags(m, &dataGroup)
+		b, err := json.Marshal(dataGroup)
+		if err != nil {
+			fmt.Println("error:", err)
+		}
+		metricGroup = metricGroup + string(b)
 	}
 
-    return metricGroup, nil
+	return metricGroup, nil
 }
 
 func buildHecTags(m telegraf.Metric, tsData *HECTimeSeries) {
 
-    obj := map[string]interface{}{}
+	obj := map[string]interface{}{}
 
-    // Copy all of the existing fields into a new map
-    for k,v := range tsData.Fields.(map[string]interface{}){
-        obj[k] = v
-    }
-    /*
-    ** Iterate tags and copy them into fields{}
-    ** Check for host in m.Tags() and set in tsData.Host
-    */
-	//tags := make([]string, len(m.Tags()))
+	// Copy all of the existing fields into a new map
+	for k, v := range tsData.Fields.(map[string]interface{}) {
+		obj[k] = v
+	}
+	/*
+	 ** Iterate tags and copy them into fields{}
+	 ** Check for host in m.Tags() and set in tsData.Host
+	 */
 	for k, v := range m.Tags() {
-	    if k == "host" {
-            tsData.Host = v
-        } else {
-		    obj[k] = v
-        }
-    }
-    // Set the updated set of Fields into tsData
-    tsData.Fields = obj
+		if k == "host" {
+			tsData.Host = v
+		} else {
+			obj[k] = v
+		}
+	}
+	// Set the updated set of Fields into tsData
+	tsData.Fields = obj
 }
 
 func verifyValue(v interface{}) bool {

--- a/plugins/outputs/splunkhec/splunkhec.go
+++ b/plugins/outputs/splunkhec/splunkhec.go
@@ -1,0 +1,212 @@
+package splunkhec
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/outputs"
+)
+
+type SplunkHEC struct {
+	Token  string
+	Url string
+    Index string
+    Source string
+
+	Timeout internal.Duration
+	client *http.Client
+}
+
+var sampleConfig = `
+  ## Splunk HEC Token (also used for Data Channel ID)
+  token = "my-secret-key" # required.
+
+  ## Splunk HEC endpoint
+  url = "https://localhost:8088/services/collector" # required.
+
+  ## Splunk Index: Must be a metrics index, must be allowed by above token
+  # index = "telegraf"
+
+  ## Source: Set the 'source' on the events (defaults to: telegraf)
+  # source = "telegraf"
+
+  ## Connection timeout.
+  # timeout = "5s"
+`
+
+
+/* Splunk HEC Structs */
+type HECTimeSeries struct {
+    Time    float64     `json:"time"`
+    Event   string      `json:"event"`
+    Index   string      `json:"index,omitempty"`
+    Source  string      `json:"source,omitempty"`
+    Host    string      `json:"host"`
+    Fields  interface{} `json:"fields"`
+
+}
+
+
+func NewSplunkHEC() *SplunkHEC {
+	return &SplunkHEC{
+	}
+}
+
+func (d *SplunkHEC) Connect() error {
+	if d.Token == "" {
+		return fmt.Errorf("token is a required field for Splunk HEC output")
+	}
+	if d.Url == "" {
+		return fmt.Errorf("url is a required field for Splunk HEC output")
+	}
+
+	d.client = &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
+		Timeout: d.Timeout.Duration,
+	}
+	return nil
+}
+
+func (d *SplunkHEC) Write(metrics []telegraf.Metric) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+    var hecPostData string
+
+	for _, m := range metrics {
+		if hecMs, err := buildMetrics(m,d); err == nil {
+            hecPostData = hecPostData+string(hecMs)
+        } else {
+			log.Printf("I! unable to build Metric for %s, skipping\n", m.Name())
+		}
+	}
+
+	redactedApiKey := "****************"
+
+	req, err := http.NewRequest("POST", d.Url, strings.NewReader(hecPostData))
+	if err != nil {
+		return fmt.Errorf("unable to create http.Request, %s\n", strings.Replace(err.Error(), d.Token, redactedApiKey, -1))
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", "Splunk "+d.Token)
+    // Add the Request-Channel header incase Indexer Acknowledgment is enabled.
+	req.Header.Add("X-Splunk-Request-Channel", d.Token)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error POSTing metrics, %s\n", strings.Replace(err.Error(), d.Token, redactedApiKey, -1))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 209 {
+		return fmt.Errorf("received bad status code, %d\n", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (d *SplunkHEC) SampleConfig() string {
+	return sampleConfig
+}
+
+func (d *SplunkHEC) Description() string {
+	return "Configuration for Splunk HEC to send metrics to.\nDoes not make use of Indexer Acknowledgement"
+}
+
+func buildMetrics(m telegraf.Metric,d *SplunkHEC) (string, error) {
+
+    var metricGroup string
+    dataGroup := HECTimeSeries{}
+    obj := map[string]interface{}{}
+
+	for k, v := range m.Fields() {
+        // Empty out anything in obj since I don't know how golang scoping works...
+        for k,_ := range obj {
+	        delete(obj,k)
+	    }
+        dataGroup = HECTimeSeries{}
+        obj["metric_name"] = m.Name()+"."+k
+        obj["_value"] = v
+
+        dataGroup = HECTimeSeries {
+            Time:   float64(m.Time().UnixNano()/1000000000),
+            Event:  "metric",
+            Fields: obj,
+        }
+
+	    if d.Source != "" {
+            dataGroup.Source = d.Source
+        } else {
+            dataGroup.Source = "telegraf"
+        }
+	    if d.Index != "" {
+            dataGroup.Index = d.Index
+        }
+
+		if !verifyValue(v) {
+            // Reset the dataGroup
+            dataGroup = HECTimeSeries{}
+			continue
+		}
+
+        // Need to get Host from m.Tags()
+        buildHecTags(m, &dataGroup)
+        b, err := json.Marshal(dataGroup)
+        if err != nil {
+            fmt.Println("error:", err)
+        }
+        metricGroup = metricGroup+string(b)
+	}
+
+    return metricGroup, nil
+}
+
+func buildHecTags(m telegraf.Metric, tsData *HECTimeSeries) {
+
+    obj := map[string]interface{}{}
+
+    // Copy all of the existing fields into a new map
+    for k,v := range tsData.Fields.(map[string]interface{}){
+        obj[k] = v
+    }
+    /*
+    ** Iterate tags and copy them into fields{}
+    ** Check for host in m.Tags() and set in tsData.Host
+    */
+	//tags := make([]string, len(m.Tags()))
+	for k, v := range m.Tags() {
+	    if k == "host" {
+            tsData.Host = v
+        } else {
+		    obj[k] = v
+        }
+    }
+    // Set the updated set of Fields into tsData
+    tsData.Fields = obj
+}
+
+func verifyValue(v interface{}) bool {
+	switch v.(type) {
+	case string:
+		return false
+	}
+	return true
+}
+
+func (d *SplunkHEC) Close() error {
+	return nil
+}
+
+func init() {
+	outputs.Add("splunkhec", func() telegraf.Output {
+		return NewSplunkHEC()
+	})
+}

--- a/plugins/outputs/splunkhec/splunkhec_test.go
+++ b/plugins/outputs/splunkhec/splunkhec_test.go
@@ -1,0 +1,29 @@
+package splunkhec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStructure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	//MockMetrics returns a single event that matches this:
+	const validResult = "{\"time\":1257894000,\"event\":\"metric\",\"source\":\"telegraf\",\"host\":\"\",\"fields\":{\"_value\":1,\"metric_name\":\"test1.value\",\"tag1\":\"value1\"}}"
+
+	d := &SplunkHEC{}
+
+	v, _ := json.Marshal(validResult)
+
+	if hecMs, err := buildMetrics(testutil.MockMetrics()[0], d); err == nil {
+		b, err := json.Marshal(hecMs)
+		if assert.Nil(t, err) {
+			assert.Equal(t, v, b)
+		}
+	}
+}

--- a/plugins/outputs/splunkhec/splunkhec_test.go
+++ b/plugins/outputs/splunkhec/splunkhec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStructure(t *testing.T) {
@@ -20,10 +20,9 @@ func TestStructure(t *testing.T) {
 
 	v, _ := json.Marshal(validResult)
 
-	if hecMs, err := buildMetrics(testutil.MockMetrics()[0], d); err == nil {
-		b, err := json.Marshal(hecMs)
-		if assert.Nil(t, err) {
-			assert.Equal(t, v, b)
-		}
-	}
+	hecMs, err := buildMetrics(testutil.MockMetrics()[0], d)
+    require.NoError(t, err)
+	b, err := json.Marshal(hecMs)
+	require.NoError(t, err)
+	require.Equal(t, v, b)
 }


### PR DESCRIPTION
### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [X ] Associated README.md updated.
- [X ] Has appropriate unit tests.

Splunk HEC output allows you to send metrics directly to Splunk via the HTTP Event Collector (HEC) in a pipelined manner.

Allows you to set the following configuraiton:

HEC Token (required): Token to use
URL (required): URL of the HEC
Index: defaults to 'telegraf'
Source: defaults to 'telegraf'
Timeout: Connection timeout (defaults to 5s)
This plugin doesn't make use of Splunk Indexer Acknowledgment,
but doesn't break if it's configured.

Should satisfy:
influxdata#3176

Also brings the TiVo fork up to current.